### PR TITLE
Fix to handle nil payload  in request data

### DIFF
--- a/src/httpd_req.lua
+++ b/src/httpd_req.lua
@@ -23,7 +23,11 @@ local function httpdRequest(data)
   httpdRequestHandler.method = method
   httpdRequestHandler.path = path
   httpdRequestHandler.contentType = string.match(data, "Content%-Type: ([%w/-]+)")
-  httpdRequestHandler.body = string.sub(data, string.find(data, "\r\n\r\n", 1, true), #data)
+
+  payload = string.find(data, "\r\n\r\n", 1, true)
+  if payload ~= nil then
+    httpdRequestHandler.body = string.sub(data, payload, #data)
+  end
 
   if httpdRequestHandler.contentType == "application/json" then
     httpdRequestHandler.body = sjson.decode(httpdRequestHandler.body)


### PR DESCRIPTION
Error below occurs when a rouge request is received from an unknown origin on my network.
```
Heap:   28320   UPnP:   Sent SSDP NOTIFY
PANIC: unprotected error in call to Lua API (/opt/nodemcu-firmware/local/fs/httpd_req.lua:26: bad argument #2 to 'sub' (number expected, got nil))
```
Ran the patched code (including else statement to track occurrences) for 72 hours with no recurrence.