### PR TITLE
Edits to reduce spammy log entries on Hubitat

### DIFF
--- a/hubitat/apps/konnected-connect.groovy
+++ b/hubitat/apps/konnected-connect.groovy
@@ -13,7 +13,7 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  */
-public static String version() { return "2.2.6" }
+public static String version() { return "2.2.7" }
 
 definition(
   name:        "Konnected (Connect)",
@@ -32,6 +32,7 @@ preferences {
     section {
       app(name: "childApps", appName: "Konnected Service Manager", namespace: "konnected-io", title: "Add a Konnected device", multiple: true)
       paragraph "Konnected (Connect) v${version()}"
+      input name: "debugOutput", type: "bool", title: "Enable debug logging?", defaultValue: true
     }
   }
 }
@@ -44,6 +45,7 @@ def installed() {
 def updated() {
   log.info "updated(): Updating Konnected SmartApp"
   unschedule()
+  if (debugOutput) runIn(1800,logsOff)
   initialize()
 }
 
@@ -57,7 +59,7 @@ def initialize() {
 
 // Device Discovery : Send M-Search to multicast
 def discoverySearch() {
-  log.debug "Discovering Konnected devices on the network via SSDP"
+  logDebug "Discovering Konnected devices on the network via SSDP"
   sendHubCommand(new hubitat.device.HubAction("lan discovery ${discoveryDeviceType()}", hubitat.device.Protocol.LAN))
 }
 
@@ -71,7 +73,7 @@ void registerKnownDevice(mac) {
   }
 
   if (isNewDevice(mac)) {
-    log.debug "Registering Konnected device ${mac}"
+    log.info "Registering Konnected device ${mac}"
   	state.knownDevices.add(mac)
   }
 }
@@ -83,3 +85,15 @@ void removeKnownDevice(mac) {
 Boolean isNewDevice(mac) {
   return !state.knownDevices?.contains(mac)
 }
+
+def logsOff(){
+  log.warn "debug logging disabled..."
+  device.updateSetting("debugOutput",[value:"false",type:"bool"])
+}
+
+private logDebug(msg) {
+  if (settings.debugOutput || settings.debugOutput == null) {
+    log.debug "$msg"
+  }
+}
+

--- a/hubitat/apps/konnected-service-manager.groovy
+++ b/hubitat/apps/konnected-service-manager.groovy
@@ -13,7 +13,7 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  */
-public static String version() { return "2.2.6" }
+public static String version() { return "2.2.7" }
 
 definition(
   name:        "Konnected Service Manager",
@@ -51,17 +51,14 @@ def updated() {
   log.info "updated(): Updating Konnected Device: " + state.device?.mac
   unsubscribe()
   unschedule()
+  if (debugOutput) runIn(1800,logsOff)
   initialize()
 }
 
 def uninstalled() {
   def device = state.device
   log.info "uninstall(): Removing Konnected Device $device?.mac"
-
-  getAllChildDevices().each {
-	log.info "deleting device: $it"
-	deleteChildDevice(it.deviceNetworkId)
-  }
+  revokeAccessToken()
 
   def body = [
     token : "",
@@ -242,6 +239,12 @@ private pageAssignPins() {
           required: false,
           defaultValue: true
         )
+        input(
+          name: "debugOutput",
+          type: "bool",
+          title: "Enable debug logging?",
+          defaultValue: true
+        )
         href(
           name: "changePinMapping",
           page: "pageSelectHwType",
@@ -291,10 +294,10 @@ def discoverySearchHandler(evt) {
   if (device?.ssdpUSN == ssdpUSN) {
     device.networkAddress = event.networkAddress
     device.deviceAddress = event.deviceAddress
-    log.debug "Refreshed attributes of device $device"
+    logDebug "Refreshed attributes of device $device"
   } else if (device == null && parent.isNewDevice(event.mac)) {
     state.device = event
-    log.debug "Discovered new device $event"
+    logDebug "Discovered new device $event"
     unsubscribe()
     discoveryVerify(event)
   }
@@ -302,7 +305,7 @@ def discoverySearchHandler(evt) {
 
 // Device Discovery : Verify a Device
 def discoveryVerify(Map device) {
-  log.debug "Verifying communication with device $device"
+  logDebug "Verifying communication with device $device"
   String host = getDeviceIpAndPort(device)
   sendHubCommand(
     new hubitat.device.HubAction(
@@ -319,7 +322,7 @@ def discoveryVerificationHandler(hubitat.device.HubResponse hubResponse) {
   def body = hubResponse.xml
   def device = state.device
   if (device?.ssdpUSN.contains(body?.device?.UDN?.text())) {
-    log.debug "Verification Success: $body"
+    logDebug "Verification Success: $body"
     device.name =  body?.device?.roomName?.text()
     device.model = body?.device?.modelName?.text()
     device.serialNumber = body?.device?.serialNum?.text()
@@ -367,7 +370,7 @@ def childDeviceConfiguration() {
   }
 
   deleteChildDevices.each {
-    log.debug "Deleting device $it.deviceNetworkId"
+    logDebug "Deleting device $it.deviceNetworkId"
     deleteChildDevice(it.deviceNetworkId)
   }
 }
@@ -381,17 +384,17 @@ def childDeviceStateUpdate() {
   def device = getChildDevice(deviceId)
   if (device) {
   	if (request.JSON?.temp) {
-        log.debug "Temp: $request.JSON"
+        logDebug "Temp: $request.JSON"
     	device.updateStates(request.JSON)
     } else {
 	    def newState = params.deviceState ?: request.JSON.state.toString()
-      log.debug "Received sensor update from Konnected device: $deviceId = $newState"
+      logDebug "Received sensor update from Konnected device: $deviceId = $newState"
 	    device.setStatus(newState)
     }
   } else {
   	if (addr) {
       // New device found at this address, create it
-      log.debug "Adding new thing attached to Konnected: $deviceId"
+      logDebug "Adding new thing attached to Konnected: $deviceId"
       device = addChildDevice("konnected-io", settings."deviceType_$pin", deviceId, state.device.hub, [ "label": addr , "completedSetup": true ])
       device.updateStates(request.JSON)
     } else {
@@ -444,12 +447,12 @@ def updateSettingsOnDevice() {
     }
   }
 
-  log.debug "Configured sensors on $mac: $sensors"
-  log.debug "Configured actuators on $mac: $actuators"
-  log.debug "Configured DHT sensors on $mac: $dht_sensors"
-  log.debug "Configured DS18B20 sensors on $mac: $ds18b20_sensors"
+  logDebug "Configured sensors on $mac: $sensors"
+  logDebug "Configured actuators on $mac: $actuators"
+  logDebug "Configured DHT sensors on $mac: $dht_sensors"
+  logDebug "Configured DS18B20 sensors on $mac: $ds18b20_sensors"
 
-  log.debug "Blink is: ${settings.blink}"
+  logDebug "Blink is: ${settings.blink}"
   def body = [
     token : state.accessToken,
     apiUrl : getFullLocalApiServerUrl(),
@@ -461,7 +464,7 @@ def updateSettingsOnDevice() {
     ds18b20_sensors : ds18b20_sensors
   ]
 
-  log.debug "Updating settings on device $mac at $ip"
+  logDebug "Updating settings on device $mac at $ip"
   sendHubCommand(new hubitat.device.HubAction([
     method: "PUT",
     path: "/settings",
@@ -478,7 +481,7 @@ def deviceUpdateDeviceState(deviceDNI, deviceState, Map actuatorOptions = [:]) {
   def device = state.device
 
   if (device && device.mac == deviceMac) {
-    log.debug "Updating device $deviceMac pin $deviceId to $deviceState at " + getDeviceIpAndPort(device)
+    logDebug "Updating device $deviceMac pin $deviceId to $deviceState at " + getDeviceIpAndPort(device)
     sendHubCommand(new hubitat.device.HubAction([
       method: "PUT",
       path: "/device",
@@ -547,3 +550,17 @@ private Map digitalSensorsMap() {
 
 private Integer convertHexToInt(hex) { Integer.parseInt(hex,16) }
 private String convertHexToIP(hex) { [convertHexToInt(hex[0..1]),convertHexToInt(hex[2..3]),convertHexToInt(hex[4..5]),convertHexToInt(hex[6..7])].join(".") }
+
+
+
+def logsOff(){
+  log.warn "debug logging disabled..."
+  device.updateSetting("debugOutput",[value:"false",type:"bool"])
+}
+
+private logDebug(msg) {
+  if (settings?.debugOutput || settings?.debugOutput == null) {
+    log.debug "$msg"
+  }
+}
+

--- a/hubitat/drivers/konnected-co-sensor.groovy
+++ b/hubitat/drivers/konnected-co-sensor.groovy
@@ -41,5 +41,6 @@ def isOpen() {
 def setStatus(state) {
   def stateValue = state == "1" ? isOpen() : isClosed()
   sendEvent(name: "carbonMonoxide", value: stateValue)
-  log.debug "$device.label is $stateValue"
+  log.info "$device.label is $stateValue"
 }
+

--- a/hubitat/drivers/konnected-contact-sensor.groovy
+++ b/hubitat/drivers/konnected-contact-sensor.groovy
@@ -40,5 +40,5 @@ def isOpen() {
 def setStatus(state) {
   def stateValue = state == "1" ? isOpen() : isClosed()
   sendEvent(name: "contact", value: stateValue)
-  log.debug "$device.label is $stateValue"
+  log.info "$device.label is $stateValue"
 }

--- a/hubitat/drivers/konnected-motion-sensor.groovy
+++ b/hubitat/drivers/konnected-motion-sensor.groovy
@@ -40,5 +40,5 @@ def isOpen() {
 def setStatus(state) {
   def stateValue = state == "1" ? isOpen() : isClosed()
   sendEvent(name: "motion", value: stateValue)
-  log.debug "$device.label is $stateValue"
+  log.info "$device.label is $stateValue"
 }

--- a/hubitat/drivers/konnected-panic-button.groovy
+++ b/hubitat/drivers/konnected-panic-button.groovy
@@ -40,5 +40,5 @@ def isOpen() {
 def setStatus(state) {
   def stateValue = state == "1" ? isOpen() : isClosed()
   sendEvent(name: "contact", value: stateValue)
-  log.debug "$device.label is $stateValue"
+  log.info "$device.label is $stateValue"
 }

--- a/hubitat/drivers/konnected-siren-strobe.groovy
+++ b/hubitat/drivers/konnected-siren-strobe.groovy
@@ -38,7 +38,7 @@ def updatePinState(Integer state) {
   } else {
     val = invertTrigger ? "off" : "on"
   }
-  log.debug "$device is $val"
+  log.info "$device is $val"
   sendEvent(name: "switch", value: val, displayed: false)
   if (val == "on") { val = "both" }
   sendEvent(name: "alarm", value: val)

--- a/hubitat/drivers/konnected-smoke-sensor.groovy
+++ b/hubitat/drivers/konnected-smoke-sensor.groovy
@@ -40,5 +40,5 @@ def isOpen() {
 def setStatus(state) {
   def stateValue = state == "1" ? isOpen() : isClosed()
   sendEvent(name: "smoke", value: stateValue)
-  log.debug "$device.label is $stateValue"
+  log.info "$device.label is $stateValue"
 }

--- a/hubitat/drivers/konnected-switch.groovy
+++ b/hubitat/drivers/konnected-switch.groovy
@@ -22,6 +22,7 @@ metadata {
   preferences {
     input name: "invertTrigger", type: "bool", title: "Low Level Trigger",
           description: "Select if the attached relay uses a low-level trigger. Default is high-level trigger"
+  input name: "debugOutput", type: "bool", title: "Enable debug logging?", defaultValue: false
   }
 
 }
@@ -37,19 +38,19 @@ def updatePinState(Integer state) {
   } else {
     val = invertTrigger ? "off" : "on"
   }
-  log.debug "$device is $val"
+  logDebug "$device is $val"
   sendEvent(name: "switch", value: val)
 }
 
 def off() {
   def val = invertTrigger ? 1 : 0
-  log.debug "Turning off $device.label (state = $val)"
+  logDebug "Turning off $device.label (state = $val)"
   parent.deviceUpdateDeviceState(device.deviceNetworkId, val)
 }
 
 def on() {
   def val = invertTrigger ? 0 : 1
-  log.debug "Turning on $device.label (state = $val)"
+  logDebug "Turning on $device.label (state = $val)"
   parent.deviceUpdateDeviceState(device.deviceNetworkId, val)
 }
 
@@ -64,3 +65,15 @@ def currentBinaryValue() {
     invertTrigger ? 1 : 0
   }
 }
+
+def logsOff(){
+  log.warn "debug logging disabled..."
+  device.updateSetting("debugOutput",[value:"false",type:"bool"])
+}
+
+private logDebug(msg) {
+  if (settings?.debugOutput || settings?.debugOutput == null) {
+    log.debug "$msg"
+  }
+}
+

--- a/hubitat/drivers/konnected-temperature-humidity-sensor-dht.groovy
+++ b/hubitat/drivers/konnected-temperature-humidity-sensor-dht.groovy
@@ -46,7 +46,7 @@ def updateStates(states) {
     sendEvent(name: "humidity", value: humidity.setScale(0, BigDecimal.ROUND_HALF_UP), unit: '%')
   }
 
-  log.debug "Temperature: $temperature, Humidity: $humidity"
+  log.info "Temperature: $temperature, Humidity: $humidity"
 }
 
 def pollInterval() {

--- a/hubitat/drivers/konnected-temperature-probe-ds18b20.groovy
+++ b/hubitat/drivers/konnected-temperature-probe-ds18b20.groovy
@@ -32,5 +32,5 @@ def updateStates(states) {
   	temperature = temperature * 9 / 5 + 32
   }
   sendEvent(name: "temperature", value: temperature.setScale(1, BigDecimal.ROUND_HALF_UP), unit: location.getTemperatureScale())
-  log.debug "Temperature: $temperature"
+  log.info "Temperature: $temperature"
 }

--- a/hubitat/drivers/konnected-water-sensor.groovy
+++ b/hubitat/drivers/konnected-water-sensor.groovy
@@ -38,5 +38,5 @@ def isOpen() {
 def setStatus(state) {
   def stateValue = state == "1" ? isOpen() : isClosed()
   sendEvent(name: "water", value: stateValue)
-  log.debug "$device.label is $stateValue"
+  log.info "$device.label is $stateValue"
 }


### PR DESCRIPTION
Updated Hubitat apps to disable debug logs per setting, or automatically after 1800 s.

For Konnected Switch device, added debug logging option (default off), and only log entries if debug logging is enabled.

Updated other device drivers to log state changes as info, rather than debug.

