### PR TITLE
Update lfs files to utilize structured logger

### DIFF
--- a/src/lfs/aws_iot.lua
+++ b/src/lfs/aws_iot.lua
@@ -1,5 +1,6 @@
 local module = ...
 
+local log = require("log")
 local mqtt = require('mqtt_ws')
 local settings = require('settings')
 local device_id = wifi.sta.getmac():lower():gsub(':','')
@@ -22,18 +23,18 @@ sendTimer:register(200, tmr.ALARM_AUTO, function(t)
 		t:stop()
 
 		if sensor.retry and sensor.retry > 0 then
-			print("Heap:", node.heap(), "Retry:", sensor.retry)
+			log.warn("Retry:", sensor.retry)
 		end
 
 		if sensor.retry and sensor.retry > 10 then
-			print("Heap:", node.heap(), "Retried 10 times and failed. Rebooting in 30 seconds.")
+			log.error("Retried 10 times and failed. Rebooting in 30 seconds.")
 			for k, v in pairs(sensorPut) do sensorPut[k] = nil end -- remove all pending sensor updates
 			tmr.create():alarm(30000, tmr.ALARM_SINGLE, function() node.restart() end) -- reboot in 30 sec
 		else
 			local message_id = c.msg_id
       local topic = sensor.topic or topics.sensor
 		  sensor.device_id = device_id
-			print("Heap:", node.heap(), "PUBLISH", "Message ID:", message_id, "Topic:", topic, "Payload:", sjson.encode(sensor))
+			log.info("PUBLISH", "Message ID:", message_id, "Topic:", topic, "Payload:", sjson.encode(sensor))
 			timeout:start()
 			c:publish(topic, sensor)
 			sensor.message_id = message_id
@@ -50,12 +51,12 @@ heartbeat:register(200, tmr.ALARM_AUTO, function(t)
 end)
 
 local function startLoop()
-	print("Heap:", node.heap(), 'Connecting to AWS IoT Endpoint:', settings.endpoint)
+	log.info('Connecting to AWS IoT Endpoint:', settings.endpoint)
 
 	local mqttFails = 0
 	c:on('offline', function()
 		mqttFails = mqttFails + 1
-		print("Heap:", node.heap(), "mqtt: offline", "failures:", mqttFails)
+		log.warn("mqtt: offline", "failures:", mqttFails)
 		sendTimer:stop()
 
 		if mqttFails >= 10 then
@@ -69,7 +70,7 @@ local function startLoop()
 end
 
 c:on('puback', function(_, message_id)
-  print("Heap:", node.heap(), 'PUBACK', 'Message ID:', message_id)
+  log.info('PUBACK', 'Message ID:', message_id)
 	local sensor = sensorPut[1]
 	if sensor and sensor.message_id == message_id then
 		table.remove(sensorPut, 1)
@@ -80,7 +81,7 @@ c:on('puback', function(_, message_id)
 end)
 
 c:on('message', function(_, topic, message)
-	print("Heap:", node.heap(), 'topic:', topic, 'msg:', message)
+	log.info('topic:', topic, 'msg:', message)
 	local payload = sjson.decode(message)
 	local endState = require("switch")(payload)
 
@@ -101,8 +102,8 @@ c:on('message', function(_, topic, message)
 end)
 
 c:on('connect', function()
-	print("Heap:", node.heap(), "mqtt: connected")
-	print("Heap:", node.heap(), "Subscribing to topic:", topics.switch)
+	log.info("mqtt: connected")
+	log.info("Subscribing to topic:", topics.switch)
 	c:subscribe(topics.switch)
 
 	-- update current state of actuators upon boot

--- a/src/lfs/http_ota.lua
+++ b/src/lfs/http_ota.lua
@@ -7,6 +7,7 @@
 
 local host, dir, image = ...
 
+local log = require("log")
 local doRequest, firstRec, subsRec, finalise
 local n, total, size = 0, 0
 
@@ -24,7 +25,7 @@ doRequest = function(sk,hostIP)
         "Host: "..host,
         "Connection: close",
         "", "", }, "\r\n")
-      print(request)
+      log.info(request)
       sck:send(request)
       sck:on("receive",firstRec)
     end)
@@ -36,7 +37,7 @@ firstRec = function (sck,rec)
   local i      = rec:find('\r\n\r\n',1,true) or 1
   local header = rec:sub(1,i+1):lower()
   size         = tonumber(header:match('\ncontent%-length: *(%d+)\r') or 0)
-  print(rec:sub(1, i+1))
+  log.info(rec:sub(1, i+1))
   if size > 0 then
     sck:on("receive",subsRec)
     file.open(image, 'w')
@@ -44,7 +45,7 @@ firstRec = function (sck,rec)
   else
     sck:on("receive", nil)
     sck:close()
-    print("GET failed")
+    log.warn("GET failed")
   end
 end
 
@@ -70,7 +71,7 @@ finalise = function(sck)
     -- run as separate task to maximise RAM available
     node.task.post(function() node.flashreload(image) end)
   else
-    print"Invalid save of image file"
+    log.error("Invalid save of image file")
   end
 end
 

--- a/src/lfs/httpd_req.lua
+++ b/src/lfs/httpd_req.lua
@@ -1,8 +1,10 @@
 local module = ...
 
+local log = require("log")
+
 local httpdRequestHandler = {
   method = nil,
-  query = { }, 
+  query = { },
   path = nil,
   contentType = nil,
   body = nil
@@ -33,7 +35,7 @@ local function httpdRequest(data)
       if status then
         httpdRequestHandler.body = body_obj
       else
-        print("Heap:", node.heap(), "Discarding malformed JSON", httpdRequestHandler.body)
+        log.warn("Discarding malformed JSON", httpdRequestHandler.body)
         httpdRequestHandler.body = nil
       end
     end

--- a/src/lfs/log.lua
+++ b/src/lfs/log.lua
@@ -1,0 +1,60 @@
+-- This code is adapted from https://github.com/rxi/log.lua
+local log = { _version = "0.1.0" }
+
+log.usecolor = true
+log.level = "debug"
+
+
+local modes = {
+  { name = "debug", color = "\27[36m", },
+  { name = "info",  color = "\27[32m", },
+  { name = "warn",  color = "\27[33m", },
+  { name = "error", color = "\27[31m", },
+}
+
+
+local levels = {}
+for i, v in ipairs(modes) do
+  levels[v.name] = i
+end
+
+local _tostring = tostring
+
+local tostring = function(...)
+  local t = {}
+  for i = 1, select('#', ...) do
+    local x = select(i, ...)
+    t[#t + 1] = _tostring(x)
+  end
+  return table.concat(t, " ")
+end
+
+
+for i, x in ipairs(modes) do
+  local nameupper = x.name:upper()
+  log[x.name] = function(...)
+
+    -- Return early if we're below the log level
+    if i < levels[log.level] then
+      return
+    end
+
+    local msg = tostring(...)
+
+    -- usec is not exact as rollover occurs but it works for reference purposes
+    local sec = tmr.time()
+    local usec = tmr.now() % 1000000
+
+    -- Output to console
+    print(string.format("%s[%-6s%s.%s, %s]%s: %s",
+                        log.usecolor and x.color or "",
+                        nameupper,
+                        sec, usec,
+                        node.heap(),
+                        log.usecolor and "\27[0m" or "",
+                        msg))
+
+  end
+end
+
+return log

--- a/src/lfs/log.lua
+++ b/src/lfs/log.lua
@@ -41,12 +41,9 @@ for i, x in ipairs(modes) do
 
     local msg = tostring(...)
 
-    -- usec is not exact as rollover occurs but it works for reference purposes
-    local sec = tmr.time()
-    local usec = tmr.now() % 1000000
-
     -- Output to console
-    print(string.format("%s[%-6s%s.%s, %s]%s: %s",
+    local sec, usec = rtctime.get()
+    print(string.format("%s[%-6s%11s.%06s, %s]%s: %s",
                         log.usecolor and x.color or "",
                         nameupper,
                         sec, usec,

--- a/src/lfs/mqtt_ws.lua
+++ b/src/lfs/mqtt_ws.lua
@@ -1,3 +1,4 @@
+local log = require("log")
 local mqtt_packet = require('mqtt_packet')
 
 local function emit(self, event, ...)
@@ -58,10 +59,10 @@ local function Client(aws_settings)
 	}
 
 	ws:on('receive', function(_, msg, opcode, x)
---		print("received", msg:len(), "msg:", msg, "bytes:", mqtt_packet.toHex(msg))
+--		log.info("received", msg:len(), "msg:", msg, "bytes:", mqtt_packet.toHex(msg))
 		local parsed = mqtt_packet.parse(msg)
 --		for k, v in pairs(parsed) do
---			print('>', k, v)
+--			log.info('>', k, v)
 --		end
 
 		if parsed.cmd == 4 then
@@ -74,12 +75,12 @@ local function Client(aws_settings)
 	end)
 
 	ws:on('close', function(_, status)
-		print("Heap:", node.heap(), 'websocket closed, status:', status)
+		log.info('websocket closed, status:', status)
 		client:emit('offline')
 	end)
 
 	ws:on('connection', function(_)
-		print("Heap:", node.heap(), "websocket connected")
+		log.info("websocket connected")
 		ws:send(string.char(0x10, 0x0c, 0x00, 0x04, 0x4d, 0x51, 0x54, 0x54, 0x04, 0x02, 0x00, 0x00, 0x00, 0x00), 2)
 	end)
 

--- a/src/lfs/rest_endpoint.lua
+++ b/src/lfs/rest_endpoint.lua
@@ -4,7 +4,7 @@ local log = require("log")
 
 -- print HTTP status line
 local function printHttpResponse(code, data)
-  local a = { "Heap:", node.heap(), "HTTP Call:", code }
+  local a = {"HTTP Call:", code }
   for k, v in pairs(data) do
     table.insert(a, k)
     table.insert(a, v)

--- a/src/lfs/rest_endpoint.lua
+++ b/src/lfs/rest_endpoint.lua
@@ -1,5 +1,7 @@
 local module = ...
 
+local log = require("log")
+
 -- print HTTP status line
 local function printHttpResponse(code, data)
   local a = { "Heap:", node.heap(), "HTTP Call:", code }
@@ -7,7 +9,7 @@ local function printHttpResponse(code, data)
     table.insert(a, k)
     table.insert(a, v)
   end
-  print(unpack(a))
+  log.info(unpack(a))
 end
 
 
@@ -48,7 +50,7 @@ local function startLoop(settings)
             state = actuator.trigger == gpio.LOW and gpio.HIGH or gpio.LOW
             gpio.write(actuator.pin, state)
           end
-          print("Heap:", node.heap(), "Initialized actuator Pin:", actuator.pin, "Trigger:", actuator.trigger, "Initial state:", state)
+          log.info("Initialized actuator Pin:", actuator.pin, "Trigger:", actuator.trigger, "Initial state:", state)
 
           table.remove(actuatorGet, 1)
           blinktimer:start()
@@ -75,7 +77,7 @@ local function startLoop(settings)
             -- retry up to 10 times then reboot as a failsafe
             local retry = sensor.retry or 0
             if retry == 10 then
-              print("Heap:", node.heap(), "Retried 10 times and failed. Rebooting in 30 seconds.")
+              log.error("Retried 10 times and failed. Rebooting in 30 seconds.")
               for k, v in pairs(sensorPut) do sensorPut[k] = nil end -- remove all pending sensor updates
               tmr.create():alarm(30000, tmr.ALARM_SINGLE, function() node.restart() end) -- reboot in 30 sec
             else
@@ -91,7 +93,7 @@ local function startLoop(settings)
 
     collectgarbage()
   end)
-  print("Heap:", node.heap(), "REST Endpoint:", settings.endpoint)
+  log.info("REST Endpoint:", settings.endpoint)
 end
 
 return function(settings)

--- a/src/lfs/server.lua
+++ b/src/lfs/server.lua
@@ -1,8 +1,9 @@
+local log = require("log")
 local device = require("device")
 
 -- enable discovery
 if require("settings").discovery ~= false then
-  print("Heap: ", node.heap(), 'UPnP:', 'Listening for UPnP discovery')
+  log.info('UPnP:', 'Listening for UPnP discovery')
   net.multicastJoin(wifi.sta.getip(), '239.255.255.250')
   local upnp = net.createUDPSocket()
   upnp:listen(1900, '0.0.0.0')
@@ -15,12 +16,12 @@ if require("settings").discovery ~= false then
     upnp:send(1900, '239.255.255.250', require('ssdp_notify')('upnp:rootdevice', '::upnp:rootdevice'))
     upnp:send(1900, '239.255.255.250', require('ssdp_notify')(device.id, ''))
     upnp:send(1900, '239.255.255.250', require('ssdp_notify')(device.urn, '::' .. device.urn))
-    print("Heap: ", node.heap(), 'UPnP:', 'Sent SSDP NOTIFY')
+    log.info('UPnP:', 'Sent SSDP NOTIFY')
   end)
 end
 
 -- enable HTTP server
-print("Heap: ", node.heap(), "HTTP: ", "Starting server at http://" .. wifi.sta.getip() .. ":" .. device.http_port)
+log.info("HTTP: ", "Starting server at http://" .. wifi.sta.getip() .. ":" .. device.http_port)
 local http = net.createServer(net.TCP, 10)
 http:listen(device.http_port, function(conn)
   conn:on("receive", function(c, payload)

--- a/src/lfs/server_receiver.lua
+++ b/src/lfs/server_receiver.lua
@@ -1,5 +1,7 @@
 local module = ...
 
+local log = require("log")
+
 local function httpReceiver(sck, payload)
 
   -- Some clients send POST data in multiple chunks.
@@ -21,7 +23,7 @@ local function httpReceiver(sck, payload)
   local response = require("httpd_res")()
 
   if request.method == 'OPTIONS' then
-    print("Heap: ", node.heap(), "HTTP: ", "Options")
+    log.info("HTTP: ", "Options")
     response.text(sck, "", nil, nil, table.concat({
       "Access-Control-Allow-Methods: POST, GET, PUT, OPTIONS\r\n",
       "Access-Control-Allow-Headers: Content-Type\r\n"
@@ -30,7 +32,7 @@ local function httpReceiver(sck, payload)
   end
 
   if request.path == "/" then
-    print("Heap: ", node.heap(), "HTTP: ", "Index")
+    log.info("HTTP: ", "Index")
     response.file(sck, "http_index.html")
 
   elseif request.path == "/favicon.ico" then
@@ -38,22 +40,22 @@ local function httpReceiver(sck, payload)
 
   elseif request.path == "/Device.xml" then
     response.text(sck, require("ssdp")(), "text/xml")
-    print("Heap: ", node.heap(), "HTTP: ", "Discovery")
+    log.info("HTTP: ", "Discovery")
 
   elseif request.path == "/settings" then
-    print("Heap: ", node.heap(), "HTTP: ", "Settings")
+    log.info("HTTP: ", "Settings")
     response.text(sck, require("server_settings")(request))
 
   elseif request.path == "/device" then
-    print("Heap: ", node.heap(), "HTTP: ", "Device")
+    log.info("HTTP: ", "Device")
     response.text(sck, require("server_device")(request))
 
   elseif request.path == "/status" then
-    print("Heap: ", node.heap(), "HTTP: ", "Status")
+    log.info("HTTP: ", "Status")
     response.text(sck, sjson.encode(require("server_status")()))
 
   elseif request.path == "/ota" then
-    print("Heap: ", node.heap(), "HTTP: ", "OTA Update")
+    log.info("HTTP: ", "OTA Update")
     response.text(sck, require("ota")(request))
   end
 

--- a/src/lfs/server_settings.lua
+++ b/src/lfs/server_settings.lua
@@ -1,4 +1,7 @@
 local module = ...
+
+local log = require("log")
+
 local restartTimer = tmr.create()
 restartTimer:register(2000, tmr.ALARM_SINGLE, function() node.restart() end)
 local function process(request)
@@ -31,7 +34,7 @@ local function process(request)
 		setVar("dht_sensors", require("variables_build")(request.body.dht_sensors))
 		setVar("ds18b20_sensors", require("variables_build")(request.body.ds18b20_sensors))
 
-		print("Heap:", node.heap(), 'Settings updated! Restarting in 5 seconds...')
+		log.warn('Settings updated! Restarting in 5 seconds...')
 		restartTimer:start()
 
 		return ""

--- a/src/lfs/ssdp_response.lua
+++ b/src/lfs/ssdp_response.lua
@@ -1,11 +1,13 @@
 local module = ...
 
+local log = require("log")
+
 local function ssdpResponse(c, d, port, ip)
   if string.match(d, "M-SEARCH") then
     local device = require("device")
     local urn = d:match("ST: (urn:[%w%p]*)")
     if (urn == device.urn or string.match(d, "ST: ssdp:all")) then
-      print("Heap: ", node.heap(), "Responding to UPnP Discovery request from " .. ip .. ":" .. port)
+      log.info("Responding to UPnP Discovery request from " .. ip .. ":" .. port)
       local resp =
       "HTTP/1.1 200 OK\r\n" ..
         "CACHE-CONTROL: max-age=1800\r\n" ..

--- a/src/lfs/start.lua
+++ b/src/lfs/start.lua
@@ -1,7 +1,9 @@
+local log = require("log")
+
 for fn in pairs(file.list()) do
   local fm = string.match(fn,".*%.lua-$")
   if (fm) and fm ~= "init.lua" then
-    print("Heap: ", node.heap(), "Compiling: ", fn)
+    log.info("Compiling: ", fn)
     node.compile(fm)
     file.remove(fm)
   end

--- a/src/lfs/switch.lua
+++ b/src/lfs/switch.lua
@@ -1,5 +1,7 @@
 local module = ...
 
+local log = require("log")
+
 infiniteLoops = {}
 
 local function turnOffIn(pin, on_state, delay, times, pause)
@@ -10,16 +12,16 @@ local function turnOffIn(pin, on_state, delay, times, pause)
     infiniteLoops[pin] = true
   end
 
-  print("Heap:", node.heap(), "Actuator Pin:", pin, "Momentary:", delay, "Repeat:", times, "Pause:", pause)
+  log.info("Actuator Pin:", pin, "Momentary:", delay, "Repeat:", times, "Pause:", pause)
 
   tmr.create():alarm(delay, tmr.ALARM_SINGLE, function()
-    print("Heap:", node.heap(), "Actuator Pin:", pin, "State:", off)
+    log.info("Actuator Pin:", pin, "State:", off)
     gpio.write(pin, off)
     times = times - 1
 
     if (times > 0 or infiniteLoops[pin]) and pause then
       tmr.create():alarm(pause, tmr.ALARM_SINGLE, function()
-        print("Heap:", node.heap(), "Actuator Pin:", pin, "State:", on_state)
+        log.info("Actuator Pin:", pin, "State:", on_state)
         gpio.write(pin, on_state)
         turnOffIn(pin, on_state, delay, times, pause)
       end)
@@ -31,7 +33,7 @@ local function updatePin(payload)
   local pin = tonumber(payload.pin)
   local state = tonumber(payload.state)
   local times = tonumber(payload.times)
-  print("Heap:", node.heap(), "Actuator Pin:", pin, "State:", state)
+  log.info("Actuator Pin:", pin, "State:", state)
 
   if infiniteLoops[pin] then
     infiniteLoops[pin] = false

--- a/src/lfs/variables_set.lua
+++ b/src/lfs/variables_set.lua
@@ -1,4 +1,7 @@
 local module = ...
+
+local log = require("log")
+
 local function set(name, value)
   if not value then return end
   local fn = name .. '.lua'
@@ -8,7 +11,7 @@ local function set(name, value)
   f.close()
   node.compile(fn)
   file.remove(fn)
-  print("Heap: ", node.heap(), "Wrote: ", fn)
+  log.info("Wrote: ", fn)
   collectgarbage()
 end
 

--- a/src/lfs/wifi.lua
+++ b/src/lfs/wifi.lua
@@ -1,6 +1,8 @@
-print("Heap: ", node.heap(), "Connecting to Wifi..")
+local log = require("log")
+
+log.info("Connecting to Wifi..")
 local startWifiSetup = function()
-  print("Heap: ", node.heap(), "Entering Wifi setup mode")
+  log.info("Entering Wifi setup mode")
   wifi.eventmon.unregister(wifi.eventmon.STA_DISCONNECTED)
   wifiFailTimer:unregister()
   wifiFailTimer = nil
@@ -18,11 +20,11 @@ failsafeTimer = tmr.create()
 failsafeTimer:register(300000, tmr.ALARM_SINGLE, function() node.restart() end)
 
 wifi.eventmon.register(wifi.eventmon.STA_DISCONNECTED, function(T)
-  print("Heap: ", node.heap(), "Cannot connect to WiFi ", T.SSID, 'Reason Code:', T.reason)
+  log.warn("Cannot connect to WiFi ", T.SSID, 'Reason Code:', T.reason)
 
   if T.reason == wifi.eventmon.reason.AUTH_EXPIRE then
     -- wifi password is incorrect, immediatly enter setup mode
-    print("Heap: ", node.heap(), "Wifi password is incorrect")
+    log.warn("Wifi password is incorrect")
     startWifiSetup()
   else
     wifiFailTimer:start()
@@ -30,17 +32,17 @@ wifi.eventmon.register(wifi.eventmon.STA_DISCONNECTED, function(T)
 end)
 
 if wifi.sta.getconfig() == "" then
-  print("Heap: ", node.heap(), "WiFi not configured")
+  log.info("WiFi not configured")
   startWifiSetup()
-  print("Heap: ", node.heap(), "WiFi Setup started")
+  log.info("WiFi Setup started")
 end
 
 local bootApp = function()
-  print("Heap: ", node.heap(), "Booting Konnected application")
+  log.info("Booting Konnected application")
   require("server")
-  print("Heap: ", node.heap(), "Loaded: ", "server")
+  log.info("Loaded: ", "server")
   require("application")
-  print("Heap: ", node.heap(), "Loaded: ", "application")
+  log.info("Loaded: ", "application")
 end
 
 local _ = tmr.create():alarm(900, tmr.ALARM_AUTO, function(t)
@@ -56,7 +58,7 @@ local _ = tmr.create():alarm(900, tmr.ALARM_AUTO, function(t)
     failsafeTimer:unregister()
     failsafeTimer = nil
     local ip, nm, gw = wifi.sta.getip()
-    print("Heap: ", node.heap(), "Wifi connected with IP: ", ip, "Gateway:", gw)
+    log.info("Wifi connected with IP: ", ip, "Gateway:", gw)
 
     gpio.write(4, gpio.HIGH)
     enduser_setup.stop()
@@ -64,13 +66,13 @@ local _ = tmr.create():alarm(900, tmr.ALARM_AUTO, function(t)
     sntp.sync({gw, 'time.google.com', 'pool.ntp.org'},
       function(sec)
         tm = rtctime.epoch2cal(sec)
-        print("Heap: ", node.heap(), "Current Date/Time:",
+        log.info("Current Date/Time:",
           string.format("%04d-%02d-%02d %02d:%02d:%02d UTC",
             tm["year"], tm["mon"], tm["day"], tm["hour"], tm["min"], tm["sec"]))
         bootApp()
       end,
       function()
-        print("Heap: ", node.heap(), "Time sync failed!")
+        log.info("Time sync failed!")
         bootApp()
       end)
   end

--- a/src/lfs/wipe.lua
+++ b/src/lfs/wipe.lua
@@ -1,3 +1,5 @@
+local log = require("log")
+
 -- reset settings by holding the FLASH button (D3) for 8 seconds
 gpio.mode(3, gpio.INT)
 
@@ -12,17 +14,17 @@ wipeTmr:register(8000, tmr.ALARM_SEMI, function()
     setVar("dht_sensors", require("variables_build")({}))
     setVar("ds18b20_sensors", require("variables_build")({}))
 
-    print("Heap:", node.heap(), 'Settings updated! Restarting now')
+    log.info('Settings updated! Restarting now')
     node.restart()
   end)
 end)
 
 local function pressed(level)
   if level == gpio.LOW then
-    print("Heap:", node.heap(), "FLASH button pressed")
+    log.warn("FLASH button pressed")
     wipeTmr:start()
   else
-    print("Heap:", node.heap(), "FLASH button released")
+    log.warn("FLASH button released")
     wipeTmr:stop()
   end
 end


### PR DESCRIPTION
This PR migrates the lfs modules to utilize a logger.  Log output format shifts from 
```
Heap:   41336   HTTP:   Starting server at http://192.168.1.213:9794
Heap:   41160   Loaded:         server
Heap:   39272   REST Endpoint:  nil
Heap:   39240   Loaded:         application
Heap:   36840   UPnP:   Sent SSDP NOTIFY
```
to 

```
[INFO  14.593499, 39136]: HTTP:  Starting server at http://192.168.1.213:9794
[INFO  14.609761, 39240]: Loaded:  server
[INFO  14.819109, 37200]: REST Endpoint: nil
[INFO  14.834246, 37904]: Loaded:  application
[INFO  29.765033, 36416]: UPnP: Sent SSDP NOTIFY
```
Note that all logs now include a level, timestamp, and heap. This differs a bit from the pro board as the debug module, which exposes lines and files, isn't included in the 8266 implementation.

Using the logger seems to impact HEAP reports by about 1300 bytes. It doesn't seem it impact performance in any other notable way.
