### PR TITLE
Use luac.cross directly and check size

### DIFF
--- a/firmware/nodemcu-firmware-overlay/app/include/user_config.h
+++ b/firmware/nodemcu-firmware-overlay/app/include/user_config.h
@@ -46,7 +46,7 @@
 // a maximum 256Kb.
 
 #define LUA_FLASH_STORE 0x10000
-
+//#define LUA_FLASH_STORE 0x40000 max LFS size
 
 // By default Lua executes the file init.lua at start up.  The following
 // define allows you to replace this with an alternative startup.  Warning:
@@ -118,10 +118,10 @@
 // management, using internal timer callbacks.  Whilst many Lua developers
 // prefer to implement equivalent features in Lua, others will prefer the
 // Wifi module to do this for them.  Uncomment the following to enable
-// this functionality.  See the relevant WiFi module documentation for 
+// this functionality.  See the relevant WiFi module documentation for
 // further details, as the scope of these changes is not obvious.
 
-//  Enable the wifi.startsmart() and wifi.stopsmart()  
+//  Enable the wifi.startsmart() and wifi.stopsmart()
 //#define WIFI_SMART_ENABLE
 
 //  Enable wifi.sta.config() event callbacks

--- a/scripts/build-firmware
+++ b/scripts/build-firmware
@@ -5,7 +5,7 @@ function usage() {
     echo "usage: $0 <version>"
     echo
     echo '    version should be formatted <major>-<minor>-<patch>'
-    echo 
+    echo
     echo 'Execute from the root dir of the repo. Upon successful completion the release will be created in firmware/releases/<version>'
     echo "    ex: '$0 2-3-0'"
     exit 1
@@ -20,10 +20,12 @@ if ! [[ "${VERSION}" =~ ^[0-9]+-[0-9]+-[0-9]+ ]] ; then
     usage
 fi
 
+set -e
 FIRMWARE_PATH="${PWD}/../nodemcu-firmware"
 FIRMWARE_OVERLAY_PATH="firmware/nodemcu-firmware-overlay"
 BUILD_PATH="firmware/builds/${VERSION}"
 IMAGE_NAME="konnected-firmware-${VERSION}"
+LFS_BASE="${PWD}/src/lfs"
 
 # Copy firmware configuration from this repository to the nodemcu-firmware repo
 cp "${FIRMWARE_OVERLAY_PATH}"/app/include/* "${FIRMWARE_PATH}/app/include/"
@@ -36,12 +38,15 @@ docker run -e "INTEGER_ONLY=1" \
     --rm -ti -v "${FIRMWARE_PATH}:/opt/nodemcu-firmware" marcelstoer/nodemcu-build build
 
 # Build LFS image with application files
-docker run -e "IMAGE_NAME=lfs" \
-    --rm -ti -v "${FIRMWARE_PATH}:/opt/nodemcu-firmware" \
-    -v "${PWD}/src/lfs:/opt/lua" marcelstoer/nodemcu-build lfs-image
+LUA_FILES=$(find ${LFS_BASE} -iname "*.lua" | sed "s|${LFS_BASE}|/lfs|g")
 
-mv src/lfs/LFS_integer_lfs.img src/lfs/lfs.img
-rm -f src/lfs/LFS_float_lfs.img
+echo Adding files to LFS:
+echo ${LUA_FILES}
+docker run --rm -ti \
+  -v ${FIRMWARE_PATH}:/tools \
+  -v ${LFS_BASE}:/lfs \
+  marcelstoer/nodemcu-build /tools/luac.cross.int -m 0x10000 -f -o "/lfs/lfs.img" ${LUA_FILES}
+echo
 
 # Build SPIFFS image
 docker run \
@@ -49,7 +54,7 @@ docker run \
     -v "${PWD}/scripts:/scripts" \
     -v "${PWD}/src:/opt/lua" marcelstoer/nodemcu-build bash /scripts/build-spiffs
 
-# Create or clear the output directory and transfer files 
+# Create or clear the output directory and transfer files
 mkdir -p "${BUILD_PATH}"
 rm -rf "${BUILD_PATH}/*"
 cp "${FIRMWARE_PATH}/bin/nodemcu_integer_${IMAGE_NAME}.bin" "${BUILD_PATH}/${IMAGE_NAME}.bin"

--- a/scripts/cross-compile
+++ b/scripts/cross-compile
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 for fname in /opt/nodemcu-firmware/local/fs/*.lua ; do
-  /opt/nodemcu-firmware/luac.cross -o /opt/nodemcu-firmware/local/fs/$(basename "$fname" .lua).{lc,lua}
+  /opt/nodemcu-firmware/luac.cross.int -o /opt/nodemcu-firmware/local/fs/$(basename "$fname" .lua).{lc,lua}
 done


### PR DESCRIPTION
Previously we were using the [docker builder lfs script](https://github.com/marcelstoer/docker-nodemcu-build/blob/master/lfs-image) to create the LFS.  This worked fine but did not include a check to ensure the built lfs does not exceed to lfs partition size.

This PR now uses the docker builder to call the `luac.cross.int` directly (similar to the PRO project).  This let's us pass the `-m 10000` arg which will cause the build to fail if the compiled lfs image it too large.

I also included a comment in the user_config.h file reflecting the max lfs partition size - this can be enabled next time we do a firmware release. 