### PR TITLE
Lock endpoint and structured logger

### DIFF
--- a/firmware/nodemcu-firmware-overlay/app/include/user_modules.h
+++ b/firmware/nodemcu-firmware-overlay/app/include/user_modules.h
@@ -23,7 +23,7 @@
 #define LUA_USE_MODULES_CRYPTO
 //#define LUA_USE_MODULES_DCC
 #define LUA_USE_MODULES_DHT
-//#define LUA_USE_MODULES_ENCODER
+#define LUA_USE_MODULES_ENCODER
 #define LUA_USE_MODULES_ENDUSER_SETUP // USE_DNS in dhcpserver.h needs to be enabled for this module to work.
 #define LUA_USE_MODULES_FILE
 //#define LUA_USE_MODULES_GDBSTUB

--- a/src/lfs/application.lua
+++ b/src/lfs/application.lua
@@ -1,4 +1,5 @@
 require("wipe")
+local log = require("log")
 local sensors = require("sensors")
 local dht_sensors = require("dht_sensors")
 local ds18b20_sensors = require("ds18b20_sensors")
@@ -13,14 +14,14 @@ actuatorGet = {}
 
 -- initialize binary sensors
 for i, sensor in pairs(sensors) do
-  print("Heap:", node.heap(), "Initializing sensor pin:", sensor.pin)
+  log.info("Initializing sensor pin:", sensor.pin)
   gpio.mode(sensor.pin, gpio.INPUT, gpio.PULLUP)
 end
 
 -- initialize actuators
 for i, actuator in pairs(actuators) do
   local initialState = actuator.trigger == gpio.LOW and gpio.HIGH or gpio.LOW
-  print("Heap:", node.heap(), "Initializing actuator pin:", actuator.pin, "on:", actuator.trigger or gpio.HIGH, "off:", initialState)
+  log.info("Initializing actuator pin:", actuator.pin, "on:", actuator.trigger or gpio.HIGH, "off:", initialState)
   gpio.write(actuator.pin, initialState)
   gpio.mode(actuator.pin, gpio.OUTPUT)
   table.insert(actuatorGet, actuator)
@@ -35,17 +36,17 @@ if #dht_sensors > 0 then
     if status == dht.OK then
       local temperature_string = temp .. "." .. math.abs(temp_dec)
       local humidity_string = humi .. "." .. humi_dec
-      print("Heap:", node.heap(), "Temperature:", temperature_string, "Humidity:", humidity_string)
+      log.info("Temperature:", temperature_string, "Humidity:", humidity_string)
       table.insert(sensorPut, { pin = pin, temp = temperature_string, humi = humidity_string })
     else
-      print("Heap:", node.heap(), "DHT Status:", status)
+      log.info("DHT Status:", status)
     end
   end
 
   for i, sensor in pairs(dht_sensors) do
     local pollInterval = tonumber(sensor.poll_interval) or 0
     pollInterval = (pollInterval > 0 and pollInterval or 3) * 60 * 1000
-    print("Heap:", node.heap(), "Polling DHT on pin " .. sensor.pin .. " every " .. pollInterval .. "ms")
+    log.info("Polling DHT on pin " .. sensor.pin .. " every " .. pollInterval .. "ms")
     tmr.create():alarm(pollInterval, tmr.ALARM_AUTO, function() readDht(sensor.pin) end)
     readDht(sensor.pin)
   end
@@ -68,7 +69,7 @@ if #ds18b20_sensors > 0 then
   for i, sensor in pairs(ds18b20_sensors) do
     local pollInterval = tonumber(sensor.poll_interval) or 0
     pollInterval = (pollInterval > 0 and pollInterval or 3) * 60 * 1000
-    print("Heap:", node.heap(), "Polling DS18b20 on pin " .. sensor.pin .. " every " .. pollInterval .. "ms")
+    log.info("Polling DS18b20 on pin " .. sensor.pin .. " every " .. pollInterval .. "ms")
     local callbackFn = ds18b20Callback(sensor.pin)
     tmr.create():alarm(pollInterval, tmr.ALARM_AUTO, function() ds18b20:read_temp(callbackFn, sensor.pin, ds18b20.C) end)
     ds18b20:read_temp(callbackFn, sensor.pin, ds18b20.C)

--- a/src/lfs/http_ota.lua
+++ b/src/lfs/http_ota.lua
@@ -7,6 +7,7 @@
 
 local host, dir, image = ...
 
+local log = require("log")
 local doRequest, firstRec, subsRec, finalise
 local n, total, size = 0, 0
 
@@ -24,7 +25,7 @@ doRequest = function(sk,hostIP)
         "Host: "..host,
         "Connection: close",
         "", "", }, "\r\n")
-      print(request)
+      log.info(request)
       sck:send(request)
       sck:on("receive",firstRec)
     end)
@@ -36,7 +37,7 @@ firstRec = function (sck,rec)
   local i      = rec:find('\r\n\r\n',1,true) or 1
   local header = rec:sub(1,i+1):lower()
   size         = tonumber(header:match('\ncontent%-length: *(%d+)\r') or 0)
-  print(rec:sub(1, i+1))
+  log.info(rec:sub(1, i+1))
   if size > 0 then
     sck:on("receive",subsRec)
     file.open(image, 'w')
@@ -44,7 +45,7 @@ firstRec = function (sck,rec)
   else
     sck:on("receive", nil)
     sck:close()
-    print("GET failed")
+    log.warn("GET failed")
   end
 end
 
@@ -70,7 +71,7 @@ finalise = function(sck)
     -- run as separate task to maximise RAM available
     node.task.post(function() node.flashreload(image) end)
   else
-    print"Invalid save of image file"
+    log.error("Invalid save of image file")
   end
 end
 

--- a/src/lfs/httpd_req.lua
+++ b/src/lfs/httpd_req.lua
@@ -1,8 +1,10 @@
 local module = ...
 
+local log = require("log")
+
 local httpdRequestHandler = {
   method = nil,
-  query = { }, 
+  query = { },
   path = nil,
   contentType = nil,
   body = nil
@@ -33,7 +35,7 @@ local function httpdRequest(data)
       if status then
         httpdRequestHandler.body = body_obj
       else
-        print("Heap:", node.heap(), "Discarding malformed JSON", httpdRequestHandler.body)
+        log.warn("Discarding malformed JSON", httpdRequestHandler.body)
         httpdRequestHandler.body = nil
       end
     end

--- a/src/lfs/log.lua
+++ b/src/lfs/log.lua
@@ -1,0 +1,60 @@
+-- This code is adapted from https://github.com/rxi/log.lua
+local log = { _version = "0.1.0" }
+
+log.usecolor = true
+log.level = "debug"
+
+
+local modes = {
+  { name = "debug", color = "\27[36m", },
+  { name = "info",  color = "\27[32m", },
+  { name = "warn",  color = "\27[33m", },
+  { name = "error", color = "\27[31m", },
+}
+
+
+local levels = {}
+for i, v in ipairs(modes) do
+  levels[v.name] = i
+end
+
+local _tostring = tostring
+
+local tostring = function(...)
+  local t = {}
+  for i = 1, select('#', ...) do
+    local x = select(i, ...)
+    t[#t + 1] = _tostring(x)
+  end
+  return table.concat(t, " ")
+end
+
+
+for i, x in ipairs(modes) do
+  local nameupper = x.name:upper()
+  log[x.name] = function(...)
+
+    -- Return early if we're below the log level
+    if i < levels[log.level] then
+      return
+    end
+
+    local msg = tostring(...)
+
+    -- usec is not exact as rollover occurs but it works for reference purposes
+    local sec = tmr.time()
+    local usec = tmr.now() % 1000000
+
+    -- Output to console
+    print(string.format("%s[%-6s%s.%s, %s]%s: %s",
+                        log.usecolor and x.color or "",
+                        nameupper,
+                        sec, usec,
+                        node.heap(),
+                        log.usecolor and "\27[0m" or "",
+                        msg))
+
+  end
+end
+
+return log

--- a/src/lfs/log.lua
+++ b/src/lfs/log.lua
@@ -41,12 +41,9 @@ for i, x in ipairs(modes) do
 
     local msg = tostring(...)
 
-    -- usec is not exact as rollover occurs but it works for reference purposes
-    local sec = tmr.time()
-    local usec = tmr.now() % 1000000
-
     -- Output to console
-    print(string.format("%s[%-6s%s.%s, %s]%s: %s",
+    local sec, usec = rtctime.get()
+    print(string.format("%s[%-6s%11s.%06s, %s]%s: %s",
                         log.usecolor and x.color or "",
                         nameupper,
                         sec, usec,

--- a/src/lfs/mqtt_ws.lua
+++ b/src/lfs/mqtt_ws.lua
@@ -1,3 +1,4 @@
+local log = require("log")
 local mqtt_packet = require('mqtt_packet')
 
 local function emit(self, event, ...)
@@ -58,10 +59,10 @@ local function Client(aws_settings)
 	}
 
 	ws:on('receive', function(_, msg, opcode, x)
---		print("received", msg:len(), "msg:", msg, "bytes:", mqtt_packet.toHex(msg))
+--		log.info("received", msg:len(), "msg:", msg, "bytes:", mqtt_packet.toHex(msg))
 		local parsed = mqtt_packet.parse(msg)
 --		for k, v in pairs(parsed) do
---			print('>', k, v)
+--			log.info('>', k, v)
 --		end
 
 		if parsed.cmd == 4 then
@@ -74,12 +75,12 @@ local function Client(aws_settings)
 	end)
 
 	ws:on('close', function(_, status)
-		print("Heap:", node.heap(), 'websocket closed, status:', status)
+		log.info('websocket closed, status:', status)
 		client:emit('offline')
 	end)
 
 	ws:on('connection', function(_)
-		print("Heap:", node.heap(), "websocket connected")
+		log.info("websocket connected")
 		ws:send(string.char(0x10, 0x0c, 0x00, 0x04, 0x4d, 0x51, 0x54, 0x54, 0x04, 0x02, 0x00, 0x00, 0x00, 0x00), 2)
 	end)
 

--- a/src/lfs/rest_endpoint.lua
+++ b/src/lfs/rest_endpoint.lua
@@ -4,7 +4,7 @@ local log = require("log")
 
 -- print HTTP status line
 local function printHttpResponse(code, data)
-  local a = { "Heap:", node.heap(), "HTTP Call:", code }
+  local a = {"HTTP Call:", code }
   for k, v in pairs(data) do
     table.insert(a, k)
     table.insert(a, v)

--- a/src/lfs/rest_endpoint.lua
+++ b/src/lfs/rest_endpoint.lua
@@ -1,5 +1,7 @@
 local module = ...
 
+local log = require("log")
+
 -- print HTTP status line
 local function printHttpResponse(code, data)
   local a = { "Heap:", node.heap(), "HTTP Call:", code }
@@ -7,7 +9,7 @@ local function printHttpResponse(code, data)
     table.insert(a, k)
     table.insert(a, v)
   end
-  print(unpack(a))
+  log.info(unpack(a))
 end
 
 
@@ -48,7 +50,7 @@ local function startLoop(settings)
             state = actuator.trigger == gpio.LOW and gpio.HIGH or gpio.LOW
             gpio.write(actuator.pin, state)
           end
-          print("Heap:", node.heap(), "Initialized actuator Pin:", actuator.pin, "Trigger:", actuator.trigger, "Initial state:", state)
+          log.info("Initialized actuator Pin:", actuator.pin, "Trigger:", actuator.trigger, "Initial state:", state)
 
           table.remove(actuatorGet, 1)
           blinktimer:start()
@@ -75,7 +77,7 @@ local function startLoop(settings)
             -- retry up to 10 times then reboot as a failsafe
             local retry = sensor.retry or 0
             if retry == 10 then
-              print("Heap:", node.heap(), "Retried 10 times and failed. Rebooting in 30 seconds.")
+              log.error("Retried 10 times and failed. Rebooting in 30 seconds.")
               for k, v in pairs(sensorPut) do sensorPut[k] = nil end -- remove all pending sensor updates
               tmr.create():alarm(30000, tmr.ALARM_SINGLE, function() node.restart() end) -- reboot in 30 sec
             else
@@ -91,7 +93,7 @@ local function startLoop(settings)
 
     collectgarbage()
   end)
-  print("Heap:", node.heap(), "REST Endpoint:", settings.endpoint)
+  log.info("REST Endpoint:", settings.endpoint)
 end
 
 return function(settings)

--- a/src/lfs/server.lua
+++ b/src/lfs/server.lua
@@ -1,8 +1,9 @@
+local log = require("log")
 local device = require("device")
 
 -- enable discovery
 if require("settings").discovery ~= false then
-  print("Heap: ", node.heap(), 'UPnP:', 'Listening for UPnP discovery')
+  log.info('UPnP:', 'Listening for UPnP discovery')
   net.multicastJoin(wifi.sta.getip(), '239.255.255.250')
   local upnp = net.createUDPSocket()
   upnp:listen(1900, '0.0.0.0')
@@ -15,12 +16,12 @@ if require("settings").discovery ~= false then
     upnp:send(1900, '239.255.255.250', require('ssdp_notify')('upnp:rootdevice', '::upnp:rootdevice'))
     upnp:send(1900, '239.255.255.250', require('ssdp_notify')(device.id, ''))
     upnp:send(1900, '239.255.255.250', require('ssdp_notify')(device.urn, '::' .. device.urn))
-    print("Heap: ", node.heap(), 'UPnP:', 'Sent SSDP NOTIFY')
+    log.info('UPnP:', 'Sent SSDP NOTIFY')
   end)
 end
 
 -- enable HTTP server
-print("Heap: ", node.heap(), "HTTP: ", "Starting server at http://" .. wifi.sta.getip() .. ":" .. device.http_port)
+log.info("HTTP: ", "Starting server at http://" .. wifi.sta.getip() .. ":" .. device.http_port)
 local http = net.createServer(net.TCP, 10)
 http:listen(device.http_port, function(conn)
   conn:on("receive", function(c, payload)

--- a/src/lfs/server_lock.lua
+++ b/src/lfs/server_lock.lua
@@ -26,9 +26,7 @@ local function process(request)
         return sjson.encode({msg="missing `pwd` field"}), nil, 400
       end
 
-      local hmac = crypto.new_hmac("SHA1", request.body.pwd)
-      hmac:update(lock_str)
-      local signature = encoder.toHex(hmac:finalize())
+      local signature = encoder.toHex(crypto.hmac("SHA1", lock_str, request.body.pwd))
 
       -- if locked then try to unlock, else lock
       local setVar = require("variables_set")

--- a/src/lfs/server_lock.lua
+++ b/src/lfs/server_lock.lua
@@ -1,0 +1,64 @@
+local module = ...
+
+local log = require("log")
+local lock_str = "lockmeup"
+
+local st_locked = {state="locked"}
+local st_unlocked = {state="unlocked"}
+
+local function process(request)
+  -- Load persisted config if it exists
+  local device_config = file.exists("device_config.lc") and require("device_config") or {}
+
+  if request.method == "GET" then
+    log.info("Settings Lock status requested")
+    if device_config.lock_sig and device_config.lock_sig ~= "" then
+      return sjson.encode(st_locked)
+    end
+    return sjson.encode(st_unlocked)
+  end
+
+  if request.contentType == "application/json" then
+    if request.method == "PUT" then
+      log.info("Settings Lock update requested")
+
+      if not request.body.pwd then
+        return sjson.encode({msg="missing `pwd` field"}), nil, 400
+      end
+
+      local hmac = crypto.new_hmac("SHA1", request.body.pwd)
+      hmac:update(lock_str)
+      local signature = encoder.toHex(hmac:finalize())
+
+      -- if locked then try to unlock, else lock
+      local setVar = require("variables_set")
+      if device_config.lock_sig and device_config.lock_sig ~= ""
+       then
+        if signature == device_config.lock_sig then
+          setVar("device_config", require("variables_build")({
+            lock_sig = ""
+          }))
+          log.warn("Unlocked settings")
+          return sjson.encode(st_unlocked)
+        end
+
+        log.warn("wrong unlock password")
+        return sjson.encode({msg="incorrect value for pwd"}), nil, 403
+      else
+        setVar("device_config", require("variables_build")({
+          lock_sig = signature
+        }))
+        log.info("Settings locked w/" .. signature)
+        return sjson.encode(st_locked)
+      end
+    end
+  end
+
+  return sjson.encode({msg="unsupported request"}), nil, 400
+end
+
+return function(request)
+  package.loaded[module] = nil
+  module = nil
+  return process(request)
+end

--- a/src/lfs/server_receiver.lua
+++ b/src/lfs/server_receiver.lua
@@ -54,12 +54,12 @@ local function httpReceiver(sck, payload)
     log.info("HTTP: ", "Status")
     response.text(sck, sjson.encode(require("server_status")()))
 
-  elseif request.path == "/ota" then
-    log.info("HTTP: ", "OTA Update")
-    response.text(sck, require("ota")(request))
-
   elseif request.path == "/lock" then
     log.info("HTTP: ", "Lock")
+    response.text(sck, require("server_lock")(request))
+
+  elseif request.path == "/ota" then
+    log.info("HTTP: ", "OTA Update")
     response.text(sck, require("ota")(request))
   end
 

--- a/src/lfs/server_receiver.lua
+++ b/src/lfs/server_receiver.lua
@@ -57,6 +57,10 @@ local function httpReceiver(sck, payload)
   elseif request.path == "/ota" then
     log.info("HTTP: ", "OTA Update")
     response.text(sck, require("ota")(request))
+
+  elseif request.path == "/lock" then
+    log.info("HTTP: ", "Lock")
+    response.text(sck, require("ota")(request))
   end
 
   sck, request, response = nil

--- a/src/lfs/server_receiver.lua
+++ b/src/lfs/server_receiver.lua
@@ -1,5 +1,7 @@
 local module = ...
 
+local log = require("log")
+
 local function httpReceiver(sck, payload)
 
   -- Some clients send POST data in multiple chunks.
@@ -21,7 +23,7 @@ local function httpReceiver(sck, payload)
   local response = require("httpd_res")()
 
   if request.method == 'OPTIONS' then
-    print("Heap: ", node.heap(), "HTTP: ", "Options")
+    log.info("HTTP: ", "Options")
     response.text(sck, "", nil, nil, table.concat({
       "Access-Control-Allow-Methods: POST, GET, PUT, OPTIONS\r\n",
       "Access-Control-Allow-Headers: Content-Type\r\n"
@@ -30,7 +32,7 @@ local function httpReceiver(sck, payload)
   end
 
   if request.path == "/" then
-    print("Heap: ", node.heap(), "HTTP: ", "Index")
+    log.info("HTTP: ", "Index")
     response.file(sck, "http_index.html")
 
   elseif request.path == "/favicon.ico" then
@@ -38,22 +40,22 @@ local function httpReceiver(sck, payload)
 
   elseif request.path == "/Device.xml" then
     response.text(sck, require("ssdp")(), "text/xml")
-    print("Heap: ", node.heap(), "HTTP: ", "Discovery")
+    log.info("HTTP: ", "Discovery")
 
   elseif request.path == "/settings" then
-    print("Heap: ", node.heap(), "HTTP: ", "Settings")
+    log.info("HTTP: ", "Settings")
     response.text(sck, require("server_settings")(request))
 
   elseif request.path == "/device" then
-    print("Heap: ", node.heap(), "HTTP: ", "Device")
+    log.info("HTTP: ", "Device")
     response.text(sck, require("server_device")(request))
 
   elseif request.path == "/status" then
-    print("Heap: ", node.heap(), "HTTP: ", "Status")
+    log.info("HTTP: ", "Status")
     response.text(sck, sjson.encode(require("server_status")()))
 
   elseif request.path == "/ota" then
-    print("Heap: ", node.heap(), "HTTP: ", "OTA Update")
+    log.info("HTTP: ", "OTA Update")
     response.text(sck, require("ota")(request))
   end
 

--- a/src/lfs/server_settings.lua
+++ b/src/lfs/server_settings.lua
@@ -20,6 +20,12 @@ local function process(request)
 		return ""
 
 	elseif (request.method == "PUT" or request.method == "POST") and request.contentType == "application/json" then
+		-- Ensure the settings lock flag isn't present
+		local device_config = file.exists("device_config.lc") and require("device_config") or {}
+		if device_config.lock_sig and device_config.lock_sig ~= "" then
+			return '{ "msg":"settings are locked" }', nil, 409
+		end
+
 		local setVar = require("variables_set")
 		setVar("settings", require("variables_build")({
 			token = request.body.token,

--- a/src/lfs/server_settings.lua
+++ b/src/lfs/server_settings.lua
@@ -1,4 +1,7 @@
 local module = ...
+
+local log = require("log")
+
 local restartTimer = tmr.create()
 restartTimer:register(2000, tmr.ALARM_SINGLE, function() node.restart() end)
 local function process(request)
@@ -31,7 +34,7 @@ local function process(request)
 		setVar("dht_sensors", require("variables_build")(request.body.dht_sensors))
 		setVar("ds18b20_sensors", require("variables_build")(request.body.ds18b20_sensors))
 
-		print("Heap:", node.heap(), 'Settings updated! Restarting in 5 seconds...')
+		log.warn('Settings updated! Restarting in 5 seconds...')
 		restartTimer:start()
 
 		return ""

--- a/src/lfs/ssdp_response.lua
+++ b/src/lfs/ssdp_response.lua
@@ -1,12 +1,14 @@
 local module = ...
 
+local log = require("log")
+
 local function ssdpResponse(c, d, port, ip)
   if string.match(d, "M-SEARCH") then
     local device = require("device")
     local info = node.info("sw_version")
     local urn = d:match("ST: (urn:[%w%p]*)")
     if (urn == device.urn or string.match(d, "ST: ssdp:all")) then
-      print("Heap: ", node.heap(), "Responding to UPnP Discovery request from " .. ip .. ":" .. port)
+      log.info("Responding to UPnP Discovery request from " .. ip .. ":" .. port)
       local resp =
       "HTTP/1.1 200 OK\r\n" ..
         "CACHE-CONTROL: max-age=1800\r\n" ..

--- a/src/lfs/start.lua
+++ b/src/lfs/start.lua
@@ -1,7 +1,9 @@
+local log = require("log")
+
 for fn in pairs(file.list()) do
   local fm = string.match(fn,".*%.lua-$")
   if (fm) and fm ~= "init.lua" then
-    print("Heap: ", node.heap(), "Compiling: ", fn)
+    log.info("Compiling: ", fn)
     node.compile(fm)
     file.remove(fm)
   end

--- a/src/lfs/switch.lua
+++ b/src/lfs/switch.lua
@@ -1,5 +1,7 @@
 local module = ...
 
+local log = require("log")
+
 infiniteLoops = {}
 
 local function turnOffIn(pin, on_state, delay, times, pause)
@@ -10,16 +12,16 @@ local function turnOffIn(pin, on_state, delay, times, pause)
     infiniteLoops[pin] = true
   end
 
-  print("Heap:", node.heap(), "Actuator Pin:", pin, "Momentary:", delay, "Repeat:", times, "Pause:", pause)
+  log.info("Actuator Pin:", pin, "Momentary:", delay, "Repeat:", times, "Pause:", pause)
 
   tmr.create():alarm(delay, tmr.ALARM_SINGLE, function()
-    print("Heap:", node.heap(), "Actuator Pin:", pin, "State:", off)
+    log.info("Actuator Pin:", pin, "State:", off)
     gpio.write(pin, off)
     times = times - 1
 
     if (times > 0 or infiniteLoops[pin]) and pause then
       tmr.create():alarm(pause, tmr.ALARM_SINGLE, function()
-        print("Heap:", node.heap(), "Actuator Pin:", pin, "State:", on_state)
+        log.info("Actuator Pin:", pin, "State:", on_state)
         gpio.write(pin, on_state)
         turnOffIn(pin, on_state, delay, times, pause)
       end)
@@ -31,7 +33,7 @@ local function updatePin(payload)
   local pin = tonumber(payload.pin)
   local state = tonumber(payload.state)
   local times = tonumber(payload.times)
-  print("Heap:", node.heap(), "Actuator Pin:", pin, "State:", state)
+  log.info("Actuator Pin:", pin, "State:", state)
 
   if infiniteLoops[pin] then
     infiniteLoops[pin] = false

--- a/src/lfs/variables_set.lua
+++ b/src/lfs/variables_set.lua
@@ -1,4 +1,7 @@
 local module = ...
+
+local log = require("log")
+
 local function set(name, value)
   if not value then return end
   local fn = name .. '.lua'
@@ -8,7 +11,7 @@ local function set(name, value)
   f.close()
   node.compile(fn)
   file.remove(fn)
-  print("Heap: ", node.heap(), "Wrote: ", fn)
+  log.info("Wrote: ", fn)
   collectgarbage()
 end
 

--- a/src/lfs/variables_set.lua
+++ b/src/lfs/variables_set.lua
@@ -12,6 +12,7 @@ local function set(name, value)
   node.compile(fn)
   file.remove(fn)
   log.info("Wrote: ", fn)
+  package.loaded[name] = nil
   collectgarbage()
 end
 

--- a/src/lfs/wifi.lua
+++ b/src/lfs/wifi.lua
@@ -1,6 +1,8 @@
-print("Heap: ", node.heap(), "Connecting to Wifi..")
+local log = require("log")
+
+log.info("Connecting to Wifi..")
 local startWifiSetup = function()
-  print("Heap: ", node.heap(), "Entering Wifi setup mode")
+  log.info("Entering Wifi setup mode")
   wifi.eventmon.unregister(wifi.eventmon.STA_DISCONNECTED)
   wifiFailTimer:unregister()
   wifiFailTimer = nil
@@ -18,11 +20,11 @@ failsafeTimer = tmr.create()
 failsafeTimer:register(300000, tmr.ALARM_SINGLE, function() node.restart() end)
 
 wifi.eventmon.register(wifi.eventmon.STA_DISCONNECTED, function(T)
-  print("Heap: ", node.heap(), "Cannot connect to WiFi ", T.SSID, 'Reason Code:', T.reason)
+  log.warn("Cannot connect to WiFi ", T.SSID, 'Reason Code:', T.reason)
 
   if T.reason == wifi.eventmon.reason.AUTH_EXPIRE then
     -- wifi password is incorrect, immediatly enter setup mode
-    print("Heap: ", node.heap(), "Wifi password is incorrect")
+    log.warn("Wifi password is incorrect")
     startWifiSetup()
   else
     wifiFailTimer:start()
@@ -30,17 +32,17 @@ wifi.eventmon.register(wifi.eventmon.STA_DISCONNECTED, function(T)
 end)
 
 if wifi.sta.getconfig() == "" then
-  print("Heap: ", node.heap(), "WiFi not configured")
+  log.info("WiFi not configured")
   startWifiSetup()
-  print("Heap: ", node.heap(), "WiFi Setup started")
+  log.info("WiFi Setup started")
 end
 
 local bootApp = function()
-  print("Heap: ", node.heap(), "Booting Konnected application")
+  log.info("Booting Konnected application")
   require("server")
-  print("Heap: ", node.heap(), "Loaded: ", "server")
+  log.info("Loaded: ", "server")
   require("application")
-  print("Heap: ", node.heap(), "Loaded: ", "application")
+  log.info("Loaded: ", "application")
 end
 
 local _ = tmr.create():alarm(900, tmr.ALARM_AUTO, function(t)
@@ -56,7 +58,7 @@ local _ = tmr.create():alarm(900, tmr.ALARM_AUTO, function(t)
     failsafeTimer:unregister()
     failsafeTimer = nil
     local ip, nm, gw = wifi.sta.getip()
-    print("Heap: ", node.heap(), "Wifi connected with IP: ", ip, "Gateway:", gw)
+    log.info("Wifi connected with IP: ", ip, "Gateway:", gw)
 
     gpio.write(4, gpio.HIGH)
     enduser_setup.stop()
@@ -64,13 +66,13 @@ local _ = tmr.create():alarm(900, tmr.ALARM_AUTO, function(t)
     sntp.sync({gw, 'time.google.com', 'pool.ntp.org'},
       function(sec)
         tm = rtctime.epoch2cal(sec)
-        print("Heap: ", node.heap(), "Current Date/Time:",
+        log.info("Current Date/Time:",
           string.format("%04d-%02d-%02d %02d:%02d:%02d UTC",
             tm["year"], tm["mon"], tm["day"], tm["hour"], tm["min"], tm["sec"]))
         bootApp()
       end,
       function()
-        print("Heap: ", node.heap(), "Time sync failed!")
+        log.info("Time sync failed!")
         bootApp()
       end)
   end

--- a/src/lfs/wipe.lua
+++ b/src/lfs/wipe.lua
@@ -1,3 +1,5 @@
+local log = require("log")
+
 -- reset settings by holding the FLASH button (D3) for 8 seconds
 gpio.mode(3, gpio.INT)
 
@@ -12,17 +14,17 @@ wipeTmr:register(8000, tmr.ALARM_SEMI, function()
     setVar("dht_sensors", require("variables_build")({}))
     setVar("ds18b20_sensors", require("variables_build")({}))
 
-    print("Heap:", node.heap(), 'Settings updated! Restarting now')
+    log.info('Settings updated! Restarting now')
     node.restart()
   end)
 end)
 
 local function pressed(level)
   if level == gpio.LOW then
-    print("Heap:", node.heap(), "FLASH button pressed")
+    log.warn("FLASH button pressed")
     wipeTmr:start()
   else
-    print("Heap:", node.heap(), "FLASH button released")
+    log.warn("FLASH button released")
     wipeTmr:stop()
   end
 end


### PR DESCRIPTION
This PR creates a /lock endpoint that can be used to lock and unlock the device settings. It also includes the structured logger implementation ported over from the pro board.

### Lock Endpoint
When the lock is active any attempt to update the /settings endpoint will fail with a 409 status.

NOTE: the settings lock DOES NOT currently prevent restart or restore operations on the /settings endpoint.

A GET on /lock will return the state of the device

{
"state": "locked"
}
or

{
"state": "unlocked"
}
A PUT on /lock will attempt to lock the settings. Requests must include a JSON body with a pwd member. The value of pwd should be a password which is used to validate, or create/store a signature in the device_config file. Ex request body...

{
"pwd": "SuPeR SeCrEt"
}
If the lock is active - the value pwd must be the same as the value used when the lock was created. A match will unlock the device.
If the lock is not active, a lock will be created using the value of pwd.

The response body of PUT upon success is the new state of the device (same format as returned by GET).

If an error occurs the /lock endpoint returns an appropriate http status.
400 - pwd member missing
403 - incorrect value for pwd

### Structured Logger
This PR migrates the lfs modules to utilize a logger.  Log output format shifts from 
```
Heap:   41336   HTTP:   Starting server at http://192.168.1.213:9794
Heap:   41160   Loaded:         server
Heap:   39272   REST Endpoint:  nil
Heap:   39240   Loaded:         application
Heap:   36840   UPnP:   Sent SSDP NOTIFY
```
to 

```
[INFO  14.593499, 39136]: HTTP:  Starting server at http://192.168.1.213:9794
[INFO  14.609761, 39240]: Loaded:  server
[INFO  14.819109, 37200]: REST Endpoint: nil
[INFO  14.834246, 37904]: Loaded:  application
[INFO  29.765033, 36416]: UPnP: Sent SSDP NOTIFY
```
Note that all logs now include a level, timestamp, and heap. This differs a bit from the pro board as the debug module, which exposes lines and files, isn't included in the 8266 implementation.

Using the logger seems to impact HEAP reports by about 1300 bytes. It doesn't seem it impact performance in any other notable way.
