### PR TITLE
Settings lock

### DIFF
--- a/firmware/nodemcu-firmware-overlay/app/include/user_modules.h
+++ b/firmware/nodemcu-firmware-overlay/app/include/user_modules.h
@@ -23,7 +23,7 @@
 #define LUA_USE_MODULES_CRYPTO
 //#define LUA_USE_MODULES_DCC
 #define LUA_USE_MODULES_DHT
-//#define LUA_USE_MODULES_ENCODER
+#define LUA_USE_MODULES_ENCODER
 #define LUA_USE_MODULES_ENDUSER_SETUP // USE_DNS in dhcpserver.h needs to be enabled for this module to work.
 #define LUA_USE_MODULES_FILE
 //#define LUA_USE_MODULES_GDBSTUB

--- a/src/lfs/server_lock.lua
+++ b/src/lfs/server_lock.lua
@@ -26,9 +26,7 @@ local function process(request)
         return sjson.encode({msg="missing `pwd` field"}), nil, 400
       end
 
-      local hmac = crypto.new_hmac("SHA1", request.body.pwd)
-      hmac:update(lock_str)
-      local signature = encoder.toHex(hmac:finalize())
+      local signature = encoder.toHex(crypto.hmac("SHA1", lock_str, request.body.pwd))
 
       -- if locked then try to unlock, else lock
       local setVar = require("variables_set")

--- a/src/lfs/server_lock.lua
+++ b/src/lfs/server_lock.lua
@@ -1,0 +1,64 @@
+local module = ...
+
+local log = require("log")
+local lock_str = "lockmeup"
+
+local st_locked = {state="locked"}
+local st_unlocked = {state="unlocked"}
+
+local function process(request)
+  -- Load persisted config if it exists
+  local device_config = file.exists("device_config.lc") and require("device_config") or {}
+
+  if request.method == "GET" then
+    log.info("Settings Lock status requested")
+    if device_config.lock_sig and device_config.lock_sig ~= "" then
+      return sjson.encode(st_locked)
+    end
+    return sjson.encode(st_unlocked)
+  end
+
+  if request.contentType == "application/json" then
+    if request.method == "PUT" then
+      log.info("Settings Lock update requested")
+
+      if not request.body.pwd then
+        return sjson.encode({msg="missing `pwd` field"}), nil, 400
+      end
+
+      local hmac = crypto.new_hmac("SHA1", request.body.pwd)
+      hmac:update(lock_str)
+      local signature = encoder.toHex(hmac:finalize())
+
+      -- if locked then try to unlock, else lock
+      local setVar = require("variables_set")
+      if device_config.lock_sig and device_config.lock_sig ~= ""
+       then
+        if signature == device_config.lock_sig then
+          setVar("device_config", require("variables_build")({
+            lock_sig = ""
+          }))
+          log.warn("Unlocked settings")
+          return sjson.encode(st_unlocked)
+        end
+
+        log.warn("wrong unlock password")
+        return sjson.encode({msg="incorrect value for pwd"}), nil, 403
+      else
+        setVar("device_config", require("variables_build")({
+          lock_sig = signature
+        }))
+        log.info("Settings locked w/" .. signature)
+        return sjson.encode(st_locked)
+      end
+    end
+  end
+
+  return sjson.encode({msg="unsupported request"}), nil, 400
+end
+
+return function(request)
+  package.loaded[module] = nil
+  module = nil
+  return process(request)
+end

--- a/src/lfs/server_lock.lua
+++ b/src/lfs/server_lock.lua
@@ -1,6 +1,5 @@
 local module = ...
 
-local log = require("log")
 local lock_str = "lockmeup"
 
 local st_locked = {state="locked"}
@@ -11,7 +10,7 @@ local function process(request)
   local device_config = file.exists("device_config.lc") and require("device_config") or {}
 
   if request.method == "GET" then
-    log.info("Settings Lock status requested")
+    print("Heap:", node.heap(), "Settings Lock status requested")
     if device_config.lock_sig and device_config.lock_sig ~= "" then
       return sjson.encode(st_locked)
     end
@@ -20,7 +19,7 @@ local function process(request)
 
   if request.contentType == "application/json" then
     if request.method == "PUT" then
-      log.info("Settings Lock update requested")
+      print("Heap:", node.heap(), "Settings Lock update requested")
 
       if not request.body.pwd then
         return sjson.encode({msg="missing `pwd` field"}), nil, 400
@@ -36,17 +35,17 @@ local function process(request)
           setVar("device_config", require("variables_build")({
             lock_sig = ""
           }))
-          log.warn("Unlocked settings")
+          print("Heap:", node.heap(), "Unlocked settings")
           return sjson.encode(st_unlocked)
         end
 
-        log.warn("wrong unlock password")
+        print("Heap:", node.heap(), "wrong unlock password")
         return sjson.encode({msg="incorrect value for pwd"}), nil, 403
       else
         setVar("device_config", require("variables_build")({
           lock_sig = signature
         }))
-        log.info("Settings locked w/" .. signature)
+        print("Heap:", node.heap(), "Settings locked w/" .. signature)
         return sjson.encode(st_locked)
       end
     end

--- a/src/lfs/server_receiver.lua
+++ b/src/lfs/server_receiver.lua
@@ -52,12 +52,12 @@ local function httpReceiver(sck, payload)
     print("Heap: ", node.heap(), "HTTP: ", "Status")
     response.text(sck, sjson.encode(require("server_status")()))
 
+  elseif request.path == "/lock" then
+    print("Heap: ", node.heap(), "HTTP: ", "Lock")
+    response.text(sck, require("server_lock")(request))
+
   elseif request.path == "/ota" then
     print("Heap: ", node.heap(), "HTTP: ", "OTA Update")
-    response.text(sck, require("ota")(request))
-
-  elseif request.path == "/lock" then
-    log.info("HTTP: ", "Lock")
     response.text(sck, require("ota")(request))
   end
 

--- a/src/lfs/server_receiver.lua
+++ b/src/lfs/server_receiver.lua
@@ -55,6 +55,10 @@ local function httpReceiver(sck, payload)
   elseif request.path == "/ota" then
     print("Heap: ", node.heap(), "HTTP: ", "OTA Update")
     response.text(sck, require("ota")(request))
+
+  elseif request.path == "/lock" then
+    log.info("HTTP: ", "Lock")
+    response.text(sck, require("ota")(request))
   end
 
   sck, request, response = nil

--- a/src/lfs/server_settings.lua
+++ b/src/lfs/server_settings.lua
@@ -17,6 +17,12 @@ local function process(request)
 		return ""
 
 	elseif (request.method == "PUT" or request.method == "POST") and request.contentType == "application/json" then
+		-- Ensure the settings lock flag isn't present
+		local device_config = file.exists("device_config.lc") and require("device_config") or {}
+		if device_config.lock_sig and device_config.lock_sig ~= "" then
+			return '{ "msg":"settings are locked" }', nil, 409
+		end
+
 		local setVar = require("variables_set")
 		setVar("settings", require("variables_build")({
 			token = request.body.token,

--- a/src/lfs/variables_set.lua
+++ b/src/lfs/variables_set.lua
@@ -9,6 +9,7 @@ local function set(name, value)
   node.compile(fn)
   file.remove(fn)
   print("Heap: ", node.heap(), "Wrote: ", fn)
+  package.loaded[name] = nil
   collectgarbage()
 end
 


### PR DESCRIPTION
This PR creates a /lock endpoint that can be used to lock and unlock the device settings.When the lock is active any attempt to update the /settings endpoint will fail with a 409 status.

NOTE: the settings lock DOES NOT currently prevent restart or restore operations on the /settings endpoint.

A GET on /lock will return the state of the device

{
"state": "locked"
}
or

{
"state": "unlocked"
}
A PUT on /lock will attempt to lock the settings. Requests must include a JSON body with a pwd member. The value of pwd should be a password which is used to validate, or create/store a signature in the device_config file. Ex request body...

{
"pwd": "SuPeR SeCrEt"
}
If the lock is active - the value pwd must be the same as the value used when the lock was created. A match will unlock the device.
If the lock is not active, a lock will be created using the value of pwd.

The response body of PUT upon success is the new state of the device (same format as returned by GET).

If an error occurs the /lock endpoint returns an appropriate http status.
400 - pwd member missing
403 - incorrect value for pwd