### PR TITLE
Reconnect WiFi after connection is lost

### DIFF
--- a/src/lfs/wifi.lua
+++ b/src/lfs/wifi.lua
@@ -1,4 +1,7 @@
 print("Heap: ", node.heap(), "Connecting to Wifi..")
+
+wifi.sta.sleeptype(wifi.NONE_SLEEP)
+
 local startWifiSetup = function()
   print("Heap: ", node.heap(), "Entering Wifi setup mode")
   wifi.eventmon.unregister(wifi.eventmon.STA_DISCONNECTED)
@@ -57,6 +60,9 @@ local _ = tmr.create():alarm(900, tmr.ALARM_AUTO, function(t)
     failsafeTimer = nil
     local ip, nm, gw = wifi.sta.getip()
     print("Heap: ", node.heap(), "Wifi connected with IP: ", ip, "Gateway:", gw)
+
+    -- monitor wifi for disconnects
+    require("wifi_monitor").monitor()
 
     gpio.write(4, gpio.HIGH)
     enduser_setup.stop()

--- a/src/lfs/wifi_monitor.lua
+++ b/src/lfs/wifi_monitor.lua
@@ -1,0 +1,10 @@
+local function monitor()
+    print("Heap: ", node.heap(), 'Monitoring WiFi for disconnect')
+    wifi.eventmon.register(wifi.eventmon.STA_DISCONNECTED, function(T)
+        print("Heap: ", node.heap(), "Connection to WiFi ", T.SSID, 'lost. Reason Code:', T.reason, ' - Reconnecting')
+        wifi.sta.disconnect()
+        wifi.sta.connect()
+    end)
+end
+
+return { monitor = monitor}


### PR DESCRIPTION
I've installed a Konnected board in a non frequent building. I've had the problem, that the board lost its WiFi connection, so i can't trigger an alarm and/or use the actuators. Only solution was to enter the building to force a reboot.

This PR listens for WiFi disconnects and reconnects if needed. With this fix flashed on my board, the board is reachable since a bunch of hours without a reboot. This PR may also fix some other WiFi related problems.