### PR TITLE
Fix panic when settings value is null.

### DIFF
--- a/src/lfs/variables_build.lua
+++ b/src/lfs/variables_build.lua
@@ -11,7 +11,7 @@ local function build_list(objects)
       table.insert(out, "{")
       table.insert(out, build_list(value))
       table.insert(out, "},")
-    elseif value == sjson.NULL then
+    elseif value == sjson.NULL or type(value) == "lightfunction" then
       -- skip it
     else
       table.insert(out, key)


### PR DESCRIPTION
This fixes a panic that is triggered when a null value provided in a the settings sent.

In 3.0 if the value in the table is null (without quotes) it returns a "lightfunction" instead of "nil".
This adds a check for this to prevent corrupting the settings table.