### PR TITLE
Fix OTA updates when connected to AWS.

### DIFF
--- a/src/lfs/device.lua
+++ b/src/lfs/device.lua
@@ -2,7 +2,7 @@ local me = {
   id = "uuid:8f655392-a778-4fee-97b9-4825918" .. string.format("%x", node.chipid()),
   name = "Konnected",
   hwVersion = "3.0.0",
-  swVersion = "3.1.1",
+  swVersion = "3.1.2",
   http_port = math.floor(node.chipid()/1000) + 8000,
   urn = "urn:schemas-konnected-io:device:Security:1"
 }

--- a/src/lfs/http_ota.lua
+++ b/src/lfs/http_ota.lua
@@ -68,7 +68,7 @@ finalise = function(sck)
     wifi.setmode(wifi.NULLMODE, false)
     collectgarbage();collectgarbage()
     -- run as separate task to maximise RAM available
-    node.task.post(function() node.flashreload(image) end)
+    node.task.post(function() node.LFS.reload(image) end)
   else
     print"Invalid save of image file"
   end

--- a/src/lfs/start.lua
+++ b/src/lfs/start.lua
@@ -1,6 +1,6 @@
 for fn in pairs(file.list()) do
   local fm = string.match(fn,".*%.lua-$")
-  if (fm) and fm ~= "init.lua" then
+  if (fm) and fm ~= "init.lua" and fm ~= "ota_update.lua" then
     print("Heap: ", node.heap(), "Compiling: ", fn)
     node.compile(fm)
     file.remove(fm)

--- a/src/lfs/wifi.lua
+++ b/src/lfs/wifi.lua
@@ -29,11 +29,18 @@ if wifi.sta.getconfig() == "" then
 end
 
 local bootApp = function()
-  print("Heap: ", node.heap(), "Booting Konnected application")
-  require("server")
-  print("Heap: ", node.heap(), "Loaded: ", "server")
-  require("application")
-  print("Heap: ", node.heap(), "Loaded: ", "application")
+  if file.exists("ota_update.lua") then
+    print("Performing OTA update...")
+    local host, path, filename = require("ota_update")()
+    file.remove("ota_update.lua")
+    LFS.http_ota(host, path, filename)
+  else
+    print("Heap: ", node.heap(), "Booting Konnected application")
+    require("server")
+    print("Heap: ", node.heap(), "Loaded: ", "server")
+    require("application")
+    print("Heap: ", node.heap(), "Loaded: ", "application")
+  end
 end
 
 local _ = tmr.create():alarm(900, tmr.ALARM_AUTO, function(t)


### PR DESCRIPTION
This resolves an out of memory issue when updating via Over-The-Air while connected to a secure MQTT broker/AWS.
The process creates a file and writes the update info into it. The device is then rebooted and the file, if detected 
after connection to WiFi, is read from and the update performed using the data in the file.

Resolves #170